### PR TITLE
Update deprecatad ansi option to current argument

### DIFF
--- a/lib/docker_compose.ex
+++ b/lib/docker_compose.ex
@@ -39,6 +39,14 @@ defmodule DockerCompose do
     |> result()
   end
 
+  def version(opts) do
+    args = [compose_opts(opts), "version"] |> List.flatten()
+
+    args
+    |> execute(opts)
+    |> result()
+  end
+
   @doc """
   docker-compose down
 
@@ -156,7 +164,7 @@ defmodule DockerCompose do
   end
 
   defp execute(args, opts) do
-    System.cmd(get_executable(), wrapper_opts(opts) ++ ["--no-ansi" | args], [
+    System.cmd(get_executable(), wrapper_opts(opts) ++ ["--ansi", " never"] ++ args, [
       {:stderr_to_stdout, true} | cmd_opts(opts)
     ])
   end


### PR DESCRIPTION
Previously docker-compose accepted `--no-ansi`, current versions of docker use `--ansi ("never"|"always"|"auto")`.

The `--no-ansi` causes deprecation warnings.