### PR TITLE
Update deprecated ansi option to current argument

### DIFF
--- a/lib/docker_compose.ex
+++ b/lib/docker_compose.ex
@@ -156,7 +156,7 @@ defmodule DockerCompose do
   end
 
   defp execute(args, opts) do
-    System.cmd(get_executable(), wrapper_opts(opts) ++ ["--no-ansi" | args], [
+    System.cmd(get_executable(), wrapper_opts(opts) ++ ["--ansi", "never"] ++ args, [
       {:stderr_to_stdout, true} | cmd_opts(opts)
     ])
   end


### PR DESCRIPTION
Previously docker-compose accepted `--no-ansi`, current versions of docker use `--ansi ("never"|"always"|"auto")`.

The `--no-ansi` causes deprecation warnings.

PS: Sorry for the previous PR, I accidentality committed something extra/unnecessary.